### PR TITLE
Support multiple cameras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name='orca_camera', version='0.1', packages=['orca_camera'])
+setup(name='orca_camera', version='0.2', packages=['orca_camera'])


### PR DESCRIPTION
* Make `LibInstance` in to a singleton so that multiple `OrcaFusion` objects
  can be created while only initialising the library once.
* Expose the identity strings so that different cameras can be identified.
* Change initialisation of the camera to be in the constructor of the
  `OrcaFusion` object to simplify the interface.